### PR TITLE
Merging desktop icon settings

### DIFF
--- a/config/hooks/desktop.chroot
+++ b/config/hooks/desktop.chroot
@@ -1,4 +1,0 @@
-#!/bin/sh
-if [ -f /usr/share/applications/setxkbmap-gadget.desktop ]; then
-  cp /usr/share/applications/setxkbmap-gadget.desktop /etc/skel/Desktop/
-fi

--- a/config/includes.chroot/etc/xdg/lxsession/LXDE/autostart
+++ b/config/includes.chroot/etc/xdg/lxsession/LXDE/autostart
@@ -1,0 +1,5 @@
+@lxpanel --profile LXDE
+@pcmanfm --desktop --profile LXDE
+@xscreensaver -no-splash
+xdg-desktop-icon install --novendor /usr/local/share/applications/applications-math.desktop
+xdg-desktop-icon install --novendor /usr/share/applications/setxkbmap-gadget.desktop

--- a/config/includes.chroot/usr/local/share/applications/applications-math.desktop
+++ b/config/includes.chroot/usr/local/share/applications/applications-math.desktop
@@ -1,14 +1,11 @@
-#!/bin/sh
-mkdir -p /etc/skel/Desktop
-cat > /etc/skel/Desktop/applications-math.desktop << EOF
 [Desktop Entry]
 Name=Math Software
 Comment=Math Software
 Comment[ja]=数学ソフトウェア
+Comment[en]=Math Software
 Icon=knxm-start-penguin
 Type=Link
 Categories=Math;
 Encoding=UTF-8
 URL=file:///usr/share/applications-math/
 Exec=pcmanfm /usr/share/applications-math/
-EOF


### PR DESCRIPTION
The icons of "applications-math.desktop" and "setxkbmap-gadget.desktop" will be
installed on Desktop when LXDE starts up.

I've used an utility "xdg-desktop-icon". So we don't have to worry whether the entries
are already existing or not, or whether the folder is "Desktop" or "デスクトップ", etc.
I hope this is a better way than preparing /etc/skel/Desktop, because users sometimes
delete icons by accident and need to copy again when using persistent media.
