### PR TITLE
Adding a wrapper for kseg, which enables automatic language settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,6 @@ config/includes.chroot/usr/share/doc/mathlibre-doc
 config/includes.chroot/usr/local/sage
 config/includes.chroot/usr/local/sage-?.?
 config/includes.chroot/etc/emacs/site-start.d/99lang.*.el
-config/includes.chroot/etc/skel/.kseg
+#config/includes.chroot/etc/skel/.kseg
 config/package-lists/lang.*.list.chroot
 config/source

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ clean:
 	rm -f config/hooks/lang.*.chroot
 	rm -f config/package-lists/lang.*.list.chroot
 	rm -f config/includes.chroot/etc/emacs/site-start.d/99lang.*.el
-	rm -f config/includes.chroot/etc/skel/.kseg
+#	rm -f config/includes.chroot/etc/skel/.kseg
 
 
 distclean: clean

--- a/config/includes.chroot/etc/skel/.kseg
+++ b/config/includes.chroot/etc/skel/.kseg
@@ -1,0 +1,12 @@
+# KSeg configuration file--automatically generated in random order :)
+QuickPlayDirectory = /usr/share/doc/kseg/examples
+ViewToolbarVisible = true
+Language = kseg_en.qm
+TransformToolbarVisible = true
+NewToolbarVisible = true
+ForegroundColor = #000000
+BackgroundColor = #ffffff
+RecentListSize = 4
+MeasureToolbarVisible = true
+SelectType = BorderSelect
+LanguageDir = /usr/share/kseg

--- a/config/includes.chroot/usr/local/bin/kseg
+++ b/config/includes.chroot/usr/local/bin/kseg
@@ -1,0 +1,53 @@
+#!/bin/sh
+##
+## /usr/local/bin/kseg - a wrapper for kseg with language settings
+##
+##  starts kseg after setting the 'Language' entry in ~/.kseg.
+##  supported languages: cy,de,en,es,fr,hu,it,ja,nb,nl,pt,ru,tr,zh
+##
+
+# kseg binary
+KSEG_PROGRAM="/usr/bin/kseg"
+
+# kseg configuration files
+DOTKSEG_SYSTEM="/etc/skel/.kseg"
+DOTKSEG_USER="${HOME}/.kseg"
+
+# Checking if kseg package is installed
+if [ ! -e "${KSEG_PROGRAM}" ]
+then
+	echo "${0}: cannot find ${KSEG_PROGRAM}"
+	exit 1
+fi
+
+Configure_kseg ()
+{
+	# create ~/.kseg if it doesn't exist
+	if [ ! -e "${DOTKSEG_USER}" ]
+	then
+		if [ -r "${DOTKSEG_SYSTEM}" ]
+		then
+			cp "${DOTKSEG_SYSTEM}" "${DOTKSEG_USER}"
+		else
+			echo 'Language = kseg_en.qm' > "${DOTKSEG_USER}"
+		fi
+	fi
+
+	# add Language entry if missing
+	if [ -z "$(grep '^Language\ *=' ${DOTKSEG_USER})" ]
+	then
+		echo 'Language = kseg_en.qm' >> "${DOTKSEG_USER}"
+	fi
+
+	# overwrite Language setting
+	KSEG_LANG="${LANG%%_*}"
+	if [ -e "/usr/share/kseg/kseg_${KSEG_LANG}.qm" ]
+	then
+		KSEG_LANGFILE="kseg_${KSEG_LANG}.qm"
+	else
+		KSEG_LANGFILE="kseg_en.qm"
+	fi
+	sed -i -e "s|^\(Language\ *=\).*$|\1\ ${KSEG_LANGFILE}|" "${DOTKSEG_USER}"
+}
+
+Configure_kseg && exec ${KSEG_PROGRAM} "${@}"

--- a/lang/cn
+++ b/lang/cn
@@ -37,20 +37,20 @@ gconftool --direct --config-source xml:readwrite:/etc/gconf/gconf.xml.defaults \
 --set /desktop/ibus/general/hotkey/trigger [Control+space,Hangul,Alt+grave,Alt+Release+Alt_R,Zenkaku_Hankaku,Alt+Kanji]
 EOF
 
-#
-# for kseg
-#
-cat > config/includes.chroot/etc/skel/.kseg << EOF
-# KSeg configuration file--automatically generated in random order :)
-QuickPlayDirectory = /usr/share/doc/kseg/examples
-ViewToolbarVisible = true
-Language = kseg_zh.qm
-TransformToolbarVisible = true
-NewToolbarVisible = true
-ForegroundColor = #000000
-BackgroundColor = #ffffff
-RecentListSize = 4
-MeasureToolbarVisible = true
-SelectType = BorderSelect
-LanguageDir = /usr/share/kseg
-EOF
+# #
+# # for kseg
+# #
+# cat > config/includes.chroot/etc/skel/.kseg << EOF
+# # KSeg configuration file--automatically generated in random order :)
+# QuickPlayDirectory = /usr/share/doc/kseg/examples
+# ViewToolbarVisible = true
+# Language = kseg_zh.qm
+# TransformToolbarVisible = true
+# NewToolbarVisible = true
+# ForegroundColor = #000000
+# BackgroundColor = #ffffff
+# RecentListSize = 4
+# MeasureToolbarVisible = true
+# SelectType = BorderSelect
+# LanguageDir = /usr/share/kseg
+# EOF

--- a/lang/ja
+++ b/lang/ja
@@ -71,21 +71,21 @@ cat > config/includes.chroot/etc/emacs/site-start.d/99lang.ja.el << EOF
 (autoload 'yatex-mode "yatex" "Yet Another LaTeX mode" t)
 EOF
 
-#
-# for kseg
-#
-cat > config/includes.chroot/etc/skel/.kseg << EOF
-# KSeg configuration file--automatically generated in random order :)
-QuickPlayDirectory = /usr/share/doc/kseg/examples
-ViewToolbarVisible = true
-Language = kseg_ja.qm
-TransformToolbarVisible = true
-NewToolbarVisible = true
-ForegroundColor = #000000
-BackgroundColor = #ffffff
-RecentListSize = 4
-MeasureToolbarVisible = true
-SelectType = BorderSelect
-LanguageDir = /usr/share/kseg
-EOF
+# #
+# # for kseg
+# #
+# cat > config/includes.chroot/etc/skel/.kseg << EOF
+# # KSeg configuration file--automatically generated in random order :)
+# QuickPlayDirectory = /usr/share/doc/kseg/examples
+# ViewToolbarVisible = true
+# Language = kseg_ja.qm
+# TransformToolbarVisible = true
+# NewToolbarVisible = true
+# ForegroundColor = #000000
+# BackgroundColor = #ffffff
+# RecentListSize = 4
+# MeasureToolbarVisible = true
+# SelectType = BorderSelect
+# LanguageDir = /usr/share/kseg
+# EOF
 

--- a/lang/kh
+++ b/lang/kh
@@ -23,21 +23,21 @@ lb config \
 #
 echo "task-$LANGUAGE task-$LANGUAGE-desktop fonts-khmeros khmerconverter libreoffice-help-km" > config/package-lists/lang.$LANGUAGE.list.chroot
 
-#
-# for kseg
-#
-cat > config/includes.chroot/etc/skel/.kseg << EOF
-# KSeg configuration file--automatically generated in random order :)
-QuickPlayDirectory = /usr/share/doc/kseg/examples
-ViewToolbarVisible = true
-Language = kseg_en.qm
-TransformToolbarVisible = true
-NewToolbarVisible = true
-ForegroundColor = #000000
-BackgroundColor = #ffffff
-RecentListSize = 4
-MeasureToolbarVisible = true
-SelectType = BorderSelect
-LanguageDir = /usr/share/kseg
-EOF
+# #
+# # for kseg
+# #
+# cat > config/includes.chroot/etc/skel/.kseg << EOF
+# # KSeg configuration file--automatically generated in random order :)
+# QuickPlayDirectory = /usr/share/doc/kseg/examples
+# ViewToolbarVisible = true
+# Language = kseg_en.qm
+# TransformToolbarVisible = true
+# NewToolbarVisible = true
+# ForegroundColor = #000000
+# BackgroundColor = #ffffff
+# RecentListSize = 4
+# MeasureToolbarVisible = true
+# SelectType = BorderSelect
+# LanguageDir = /usr/share/kseg
+# EOF
 

--- a/lang/ko
+++ b/lang/ko
@@ -37,20 +37,20 @@ gconftool --direct --config-source xml:readwrite:/etc/gconf/gconf.xml.defaults \
 --set /desktop/ibus/general/hotkey/trigger [Control+space,Hangul,Alt+grave,Alt+Release+Alt_R,Zenkaku_Hankaku,Alt+Kanji]
 EOF
 
-#
-# for kseg
-#
-cat > config/includes.chroot/etc/skel/.kseg << EOF
-# KSeg configuration file--automatically generated in random order :)
-QuickPlayDirectory = /usr/share/doc/kseg/examples
-ViewToolbarVisible = true
-Language = kseg_en.qm
-TransformToolbarVisible = true
-NewToolbarVisible = true
-ForegroundColor = #000000
-BackgroundColor = #ffffff
-RecentListSize = 4
-MeasureToolbarVisible = true
-SelectType = BorderSelect
-LanguageDir = /usr/share/kseg
-EOF
+# #
+# # for kseg
+# #
+# cat > config/includes.chroot/etc/skel/.kseg << EOF
+# # KSeg configuration file--automatically generated in random order :)
+# QuickPlayDirectory = /usr/share/doc/kseg/examples
+# ViewToolbarVisible = true
+# Language = kseg_en.qm
+# TransformToolbarVisible = true
+# NewToolbarVisible = true
+# ForegroundColor = #000000
+# BackgroundColor = #ffffff
+# RecentListSize = 4
+# MeasureToolbarVisible = true
+# SelectType = BorderSelect
+# LanguageDir = /usr/share/kseg
+# EOF

--- a/lang/tw
+++ b/lang/tw
@@ -36,20 +36,20 @@ gconftool --direct --config-source xml:readwrite:/etc/gconf/gconf.xml.defaults \
 --set /desktop/ibus/general/hotkey/trigger [Control+space,Hangul,Alt+grave,Alt+Release+Alt_R,Zenkaku_Hankaku,Alt+Kanji]
 EOF
 
-#
-# for kseg
-#
-cat > config/includes.chroot/etc/skel/.kseg << EOF
-# KSeg configuration file--automatically generated in random order :)
-QuickPlayDirectory = /usr/share/doc/kseg/examples
-ViewToolbarVisible = true
-Language = kseg_tc.qm
-TransformToolbarVisible = true
-NewToolbarVisible = true
-ForegroundColor = #000000
-BackgroundColor = #ffffff
-RecentListSize = 4
-MeasureToolbarVisible = true
-SelectType = BorderSelect
-LanguageDir = /usr/share/kseg
-EOF
+# #
+# # for kseg
+# #
+# cat > config/includes.chroot/etc/skel/.kseg << EOF
+# # KSeg configuration file--automatically generated in random order :)
+# QuickPlayDirectory = /usr/share/doc/kseg/examples
+# ViewToolbarVisible = true
+# Language = kseg_tc.qm
+# TransformToolbarVisible = true
+# NewToolbarVisible = true
+# ForegroundColor = #000000
+# BackgroundColor = #ffffff
+# RecentListSize = 4
+# MeasureToolbarVisible = true
+# SelectType = BorderSelect
+# LanguageDir = /usr/share/kseg
+# EOF

--- a/lang/us
+++ b/lang/us
@@ -19,20 +19,20 @@ lb config \
 #
 echo "auctex" > config/package-lists/lang.$LANGUAGE.tex.list.chroot
 
-#
-# for kseg
-#
-cat > config/includes.chroot/etc/skel/.kseg << EOF
-# KSeg configuration file--automatically generated in random order :)
-QuickPlayDirectory = /usr/share/doc/kseg/examples
-ViewToolbarVisible = true
-Language = kseg_en.qm
-TransformToolbarVisible = true
-NewToolbarVisible = true
-ForegroundColor = #000000
-BackgroundColor = #ffffff
-RecentListSize = 4
-MeasureToolbarVisible = true
-SelectType = BorderSelect
-LanguageDir = /usr/share/kseg
-EOF
+# #
+# # for kseg
+# #
+# cat > config/includes.chroot/etc/skel/.kseg << EOF
+# # KSeg configuration file--automatically generated in random order :)
+# QuickPlayDirectory = /usr/share/doc/kseg/examples
+# ViewToolbarVisible = true
+# Language = kseg_en.qm
+# TransformToolbarVisible = true
+# NewToolbarVisible = true
+# ForegroundColor = #000000
+# BackgroundColor = #ffffff
+# RecentListSize = 4
+# MeasureToolbarVisible = true
+# SelectType = BorderSelect
+# LanguageDir = /usr/share/kseg
+# EOF


### PR DESCRIPTION
I wrote a small wrapper script for kseg to enable automatic language settings.
This script overwrites the "Language" entry in ~/.kseg, which is determined automatically
from the LANG environment variable. The default LANG is set at boot time, but we can
switch to another language at any time by changing it, e.g,

```
$ LANG=ja_JP.UTF-8 kseg
```

The wrapper will be included in the live image as "/usr/local/bin/kseg". I'm not sure we should
choose another name, but then, we will have to edit the "kseg.desktop", too.

You can try the script easily by copying it as /usr/loca/bin/kseg on your live system
(and chmod +x), before re-building the image (without modifying any other files).
